### PR TITLE
KVM MultiOS Libvirt Portfolio Code Drop for BTL-S

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -75,6 +75,7 @@ Note:
 | RPL-PS | Raptor Lake PS |
 | RPL-P | Raptor Lake P |
 | ADL-N | Alder Lake N |
+| PTL-H | Panther Lake H |
 
 Note:
 - Please contact your Intel representative for details on host IoT platform configuration and setup.
@@ -113,6 +114,7 @@ KVM MultiOS Portfolio release is laid out as summarised below.
 | Raptor Lake PS | client
 | Raptor Lake P | client
 | Alder Lake N | client
+| Panther Lake H | client
 
 ## Guest OS Domain Naming Convention, MAC/IP Address and Ports
 ***Notes***

--- a/documentation/platforms.md
+++ b/documentation/platforms.md
@@ -6,6 +6,7 @@
     1. [Amston Lake and Alder Lake N](#amston-lake-and-alder-lake-n)
     1. [Meteor Lake](#meteor-lake)
     1. [Raptor Lake P and PS](#raptor-lake-p-and-ps)
+    1. [Panther Lake H](#panther-lake-h) 
 
 # Intel IoT Platforms Supported
 | Supported Intel IoT platform | Supported Host and Guest OS Details
@@ -18,11 +19,12 @@
 | Raptor Lake PS | [refer here](platforms.md#raptor-lake-p-and-ps)
 | Raptor Lake P | [refer here](platforms.md#raptor-lake-p-and-ps)
 | Alder Lake N | [refer here](platforms.md#amston-lake-and-alder-lake-n)
+| Panther Lake H | [refer here](platforms.md#panther-lake-h)
 
 ## Bartlett Lake
 | Hardware Board Type | Silicon/Stepping/QDF | PCH Stepping/QDF |
 |:---|:---|:---|
-| Bartlett Lake – S SODIMM DDR5 RVP</br>Bartlett Lake – S UDIMM DDR5 RVP | Bartlett Lake – S Hybrid (8161/881/601) Silicon QS and beyond | Bartlett Lake - S PCH QS and beyond |
+| Bartlett Lake  S SODIMM DDR5 RVP</br>Bartlett Lake S UDIMM DDR5 RVP | Bartlett Lake S Hybrid (8161/881/601) Silicon QS and beyond <br> Bartlett Lake S12P A0 and beyond | Bartlett Lake - S PCH QS and beyond <br> Bartlett Lake S12P ES, QS and beyond |
 
 <table>
     <tr><th align="center">Host Operating System</th><th>Guest VM Operating Systems</th><th>GVT-d Supported</th><th>GPU SR-IOV Supported</th></tr>
@@ -36,16 +38,18 @@
     </tr>
     <tr>
       <td align="left"><a href="https://www.microsoft.com/en-us/evalcenter/evaluate-windows-10-enterprise">Windows 10 IoT Enterprise LTSC 21H2</a><a href="https://go.microsoft.com/fwlink/p/?linkid=2195587&clcid=0x409&culture=en-us&country=us"> (ISO download)</a></br>
-Window 10 OS patch required <a href="https://catalog.s.download.windowsupdate.com/c/msdownload/update/software/secu/2024/05/windows10.0-kb5037768-x64_a627ecbec3d8dad1754d541b7f89d534a6bdec69.msu">Windows10.0 19044.4412 (kb5037768)</a></br>
-Integrated GPU Intel(R) Graphics driver version: 101.6556</br>
-Windows Zero-copy driver release: 4.0.0.1797</br>
+Window 10 OS patch required <a href="https://catalog.s.download.windowsupdate.com/d/msdownload/update/software/secu/2025/01/windows10.0-kb5049981-x64_bda073f7d8e14e65c2632b47278924b8a0f6b374.msu">Windows10.0 19044.5371 (kb5049981)</a></br>
+BTL-S Integrated GPU Intel(R) Graphics driver version: 101.6733</br>
+BTL-S 12P Integrated GPU Intel(R) Graphics driver version:18879</br>
+Windows Zero-copy driver release: 4.0.0.1918</br>
       </td><td>NA</td><td>Yes</td>
     </tr>
     <tr>
       <td align="left"><a href="https://www.microsoft.com/en-us/evalcenter/evaluate-windows-11-enterprise">Windows 11 IoT Enterprise 24H2</a><a href="https://go.microsoft.com/fwlink/p/?linkid=2195682&clcid=0x409&culture=en-us&country=us"> (ISO download)</a></br>
-Window 11 OS patch required <a href="https://catalog.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/d8b7f92b-bd35-4b4c-96e5-46ce984b31e0/public/windows11.0-kb5043080-x64_953449672073f8fb99badb4cc6d5d7849b9c83e8.msu">Windows11.0 26100.2033 (kb5043080)</a> <a href="https://catalog.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/72f34af9-6ab3-4bb0-9dfe-103e56a305fb/public/windows11.0-kb5044284-x64_d7eb7ceaa4798b92b988fd7dcc7c6bb39476ccf3.msu">Windows11.0 26100.2033 (kb5044284)</a></br>
-Integrated GPU Intel(R) Graphics driver version: 101.6556</br>
-Windows Zero-copy driver release: 4.0.0.1797</br>
+Window 11 OS patch required <a href="https://catalog.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/d8b7f92b-bd35-4b4c-96e5-46ce984b31e0/public/windows11.0-kb5043080-x64_953449672073f8fb99badb4cc6d5d7849b9c83e8.msu">Windows11.0 26100.3037 (kb5043080)</a> <a href="https://catalog.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/2d3f9ba9-5096-4b23-9709-3af7d7a2103f/public/windows11.0-kb5050094-x64_3d5a5f9ef20fc35cc1bd2ccb08921ee8713ce622.msu">Windows11.0 26100.3037 (kb5050094)</a></br>
+BTL-S Integrated GPU Intel(R) Graphics driver version: 101.6733</br>
+BTL-S 12P Integrated GPU Intel(R) Graphics driver version:18879</br>
+Windows Zero-copy driver release: 4.0.0.1918</br>
       </td><td>NA</td><td>Yes</td>
     </tr>
 </table>
@@ -200,6 +204,37 @@ Windows Zero-copy driver release: 4.0.0.1797</br>
 Window 11 OS patch required: Windows11.0 26100.3037 <a href="https://catalog.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/d8b7f92b-bd35-4b4c-96e5-46ce984b31e0/public/windows11.0-kb5043080-x64_953449672073f8fb99badb4cc6d5d7849b9c83e8.msu">(kb5043080)</a> and <a href="https://catalog.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/2d3f9ba9-5096-4b23-9709-3af7d7a2103f/public/windows11.0-kb5050094-x64_3d5a5f9ef20fc35cc1bd2ccb08921ee8713ce622.msu">(kb5050094)</a></br>
 Integrated GPU Intel(R) Graphics driver version: 101.6556</br>
 Windows Zero-copy driver release: 4.0.0.1797</br>
+      </td><td>Yes*</td><td>Yes</td>
+    </tr>
+</table>
+
+## Panther Lake H
+| Hardware Board Type | Silicon/Stepping/QDF | PCH Stepping/QDF |
+|:---|:---|:---|
+| Panther Lake H SODIMM DDR5 CRB | Panther Lake H Silicon A0 and beyond | NA |
+
+<table>
+    <tr><th align="center">Host Operating System</th><th>Guest VM Operating Systems</th><th>GVT-d Supported</th><th>GPU SR-IOV Supported</th></tr>
+    <!-- Host Operating System -->
+    <tr>
+      <td rowspan="4" align="left">Ubuntu 24.04 release</br></td>
+    </tr>
+    <!-- Guest Operating Systems -->
+    <tr>
+      <td align="left">Ubuntu 24.04 release</br></td><td>Yes*</td><td>Yes</td>
+    </tr>
+    <tr>
+      <td align="left"><a href="https://www.microsoft.com/en-us/evalcenter/evaluate-windows-10-enterprise">Windows 10 IoT Enterprise LTSC 21H2</a><a href="https://go.microsoft.com/fwlink/p/?linkid=2195587&clcid=0x409&culture=en-us&country=us"> (ISO download)</a></br>
+Window 10 OS patch required <a href="https://catalog.s.download.windowsupdate.com/d/msdownload/update/software/secu/2025/01/windows10.0-kb5049981-x64_bda073f7d8e14e65c2632b47278924b8a0f6b374.msu">Windows10.0 19044.5371 (kb5049981)</a></br>
+Integrated GPU Intel(R) Graphics driver version: 101.6840</br>
+Windows Zero-copy driver release: 4.0.0.1918</br>
+      </td><td>Yes*</td><td>Yes</td>
+    </tr>
+    <tr>
+      <td align="left"><a href="https://www.microsoft.com/en-us/evalcenter/evaluate-windows-11-enterprise">Windows 11 IoT Enterprise 24H2</a><a href="https://go.microsoft.com/fwlink/p/?linkid=2195682&clcid=0x409&culture=en-us&country=us"> (ISO download)</a></br>
+Window 11 OS patch required: Windows11.0 26100.3037 <a href="https://catalog.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/d8b7f92b-bd35-4b4c-96e5-46ce984b31e0/public/windows11.0-kb5043080-x64_953449672073f8fb99badb4cc6d5d7849b9c83e8.msu">(kb5043080)</a> and <a href="https://catalog.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/2d3f9ba9-5096-4b23-9709-3af7d7a2103f/public/windows11.0-kb5050094-x64_3d5a5f9ef20fc35cc1bd2ccb08921ee8713ce622.msu">(kb5050094)</a></br>
+Integrated GPU Intel(R) Graphics driver version: 101.6840</br>
+Windows Zero-copy driver release: 4.0.0.1918</br>
       </td><td>Yes*</td><td>Yes</td>
     </tr>
 </table>

--- a/host_setup/ubuntu/setup_libvirt.sh
+++ b/host_setup/ubuntu/setup_libvirt.sh
@@ -90,7 +90,6 @@ if [[ "$UPDATE_LINE" != $(sudo cat "$UPDATE_FILE" | grep -F "$UPDATE_LINE") ]]; 
 fi
 
 # Update /etc/sysctl.conf
-
 # Ensure br_netfilter is loaded so the sysctl exists
 sudo modprobe br_netfilter
 
@@ -202,6 +201,10 @@ if [[ "\${2}" == "prepare" ]]; then
       fi
       modprobe i2c-algo-bit
       modprobe video
+      # Only modify auto_provisioning if the file exists
+      if [[ -f '/sys/devices/pci0000:00/0000:00:02.0/drm/card0/prelim_iov/pf/auto_provisioning' ]]; then
+        echo '1' | tee -a '/sys/devices/pci0000:00/0000:00:02.0/drm/card0/prelim_iov/pf/auto_provisioning'
+      fi
       echo '0' | tee '/sys/bus/pci/devices/0000:00:02.0/sriov_drivers_autoprobe'
       echo "\$totalvfs" | tee -a /sys/class/drm/card0/device/sriov_numvfs
       echo '1' | tee '/sys/bus/pci/devices/0000:00:02.0/sriov_drivers_autoprobe'


### PR DESCRIPTION
Bug Fixed
[NEXVIRTMOS-1453] - [PTL] Guest setup fails due to auto_provisioning with 6.14 kernel

Story Implemented
[NEXVIRTMOS-1428] - [CUSTOMER][MTL-P] Update SRIOV initialization to include auto-provisioning [NEXVIRTMOS-1455] - [DOC] Add PTL-H & BTL-S 12P Information in Platform repo